### PR TITLE
Update ubuntu version and add libfuse2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
     
     - name: Patch AppImage
       run: |
-        apt install libfuse2 -y
+        sudo apt install libfuse2 -y
         cd discord
         wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
         chmod +x *.AppImage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ jobs:
     
     - name: Patch AppImage
       run: |
+        apt install libfuse2 -y
         cd discord
         wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
         chmod +x *.AppImage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   Discord:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         version: ['3.8']
@@ -76,140 +76,140 @@ jobs:
           discord-continuous-x86_64.AppImage
         repo_token: ${{ secrets.GITHUB_TOKEN }}
 
-  Discord-PTB:
-    runs-on: ubuntu-18.04
-    strategy:
-      matrix:
-        version: ['3.8']
-    steps:
-    - uses: actions/checkout@v2
+#   Discord-PTB:
+#     runs-on: ubuntu-22.04
+#     strategy:
+#       matrix:
+#         version: ['3.8']
+#     steps:
+#     - uses: actions/checkout@v2
 
-    - name: Download Discord
-      run: |
-        mkdir discord
-        cd discord
-        wget https://discord.com/api/download/ptb\?platform\=linux\&format\=tar.gz
-        mv * discord.tar.gz
-        tar -xf discord.tar.gz
-        cd ..
+#     - name: Download Discord
+#       run: |
+#         mkdir discord
+#         cd discord
+#         wget https://discord.com/api/download/ptb\?platform\=linux\&format\=tar.gz
+#         mv * discord.tar.gz
+#         tar -xf discord.tar.gz
+#         cd ..
 
-    - name: Patch to include files
-      run: |
-        cd discord
-        cp ../AppRun DiscordPTB/.
-        chmod +x DiscordPTB/AppRun
-        sed 's,BIN="$APPDIR/Discord",BIN="$APPDIR/DiscordPTB",g' -i DiscordPTB/AppRun
-        cp ../discord.desktop DiscordPTB/.
-        cd ..
+#     - name: Patch to include files
+#       run: |
+#         cd discord
+#         cp ../AppRun DiscordPTB/.
+#         chmod +x DiscordPTB/AppRun
+#         sed 's,BIN="$APPDIR/Discord",BIN="$APPDIR/DiscordPTB",g' -i DiscordPTB/AppRun
+#         cp ../discord.desktop DiscordPTB/.
+#         cd ..
     
-    - name: Patch AppImage
-      run: |
-        cd discord
-        wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
-        chmod +x *.AppImage
-        rm DiscordPTB/discord*ptb*.desktop
-        ls DiscordPTB
-        ./appimagetool-x86_64.AppImage DiscordPTB -n -u 'gh-releases-zsync|srevinsaju|discord-appimage|canary|Discord*.AppImage.zsync' Discord-$(cat DiscordPTB/resources/build_info.json | jq -r .version)-x86_64.AppImage
-        mkdir dist
-        mv Discord*.AppImage dist/.
-        mv *.zsync dist/.
-        cd dist
-        chmod +x *.AppImage
-        cd ..
+#     - name: Patch AppImage
+#       run: |
+#         cd discord
+#         wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+#         chmod +x *.AppImage
+#         rm DiscordPTB/discord*ptb*.desktop
+#         ls DiscordPTB
+#         ./appimagetool-x86_64.AppImage DiscordPTB -n -u 'gh-releases-zsync|srevinsaju|discord-appimage|canary|Discord*.AppImage.zsync' Discord-$(cat DiscordPTB/resources/build_info.json | jq -r .version)-x86_64.AppImage
+#         mkdir dist
+#         mv Discord*.AppImage dist/.
+#         mv *.zsync dist/.
+#         cd dist
+#         chmod +x *.AppImage
+#         cd ..
        
 
-    - name: Upload artifact
-      uses: actions/upload-artifact@v1.0.0
-      with:
-        name: discord-ptb-continuous-x86_64.AppImage
-        path: 'discord/dist'
+#     - name: Upload artifact
+#       uses: actions/upload-artifact@v1.0.0
+#       with:
+#         name: discord-ptb-continuous-x86_64.AppImage
+#         path: 'discord/dist'
 
 
-  Release-PTB:
-    needs: [Discord-PTB]
-    runs-on: ubuntu-latest
+#   Release-PTB:
+#     needs: [Discord-PTB]
+#     runs-on: ubuntu-latest
 
-    steps:
-    - uses: actions/download-artifact@v1
-      with:
-        name: discord-ptb-continuous-x86_64.AppImage
+#     steps:
+#     - uses: actions/download-artifact@v1
+#       with:
+#         name: discord-ptb-continuous-x86_64.AppImage
 
-    - name: Release
-      uses: marvinpinto/action-automatic-releases@latest
-      with:
-        title: Discord Public Test AppImage Builds
-        automatic_release_tag: ptb
-        prerelease: true
-        draft: false
-        files: |
-          discord-ptb-continuous-x86_64.AppImage
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
+#     - name: Release
+#       uses: marvinpinto/action-automatic-releases@latest
+#       with:
+#         title: Discord Public Test AppImage Builds
+#         automatic_release_tag: ptb
+#         prerelease: true
+#         draft: false
+#         files: |
+#           discord-ptb-continuous-x86_64.AppImage
+#         repo_token: ${{ secrets.GITHUB_TOKEN }}
 
-  Discord-Canary:
-    runs-on: ubuntu-18.04
-    strategy:
-      matrix:
-        version: ['3.8']
-    steps:
-    - uses: actions/checkout@v2
+#   Discord-Canary:
+#     runs-on: ubuntu-22.04
+#     strategy:
+#       matrix:
+#         version: ['3.8']
+#     steps:
+#     - uses: actions/checkout@v2
 
-    - name: Download Discord
-      run: |
-        mkdir discord
-        cd discord
-        wget https://discord.com/api/download/canary\?platform\=linux\&format\=tar.gz
-        mv * discord.tar.gz
-        tar -xf discord.tar.gz
-        cd ..
+#     - name: Download Discord
+#       run: |
+#         mkdir discord
+#         cd discord
+#         wget https://discord.com/api/download/canary\?platform\=linux\&format\=tar.gz
+#         mv * discord.tar.gz
+#         tar -xf discord.tar.gz
+#         cd ..
 
-    - name: Patch to include files
-      run: |
-        cd discord
-        cp ../AppRun DiscordCanary/.
-        chmod +x DiscordCanary/AppRun
-        sed 's,BIN="$APPDIR/Discord",BIN="$APPDIR/DiscordCanary",g' -i DiscordCanary/AppRun
-        cp ../discord.desktop DiscordCanary/.
-        cd ..
+#     - name: Patch to include files
+#       run: |
+#         cd discord
+#         cp ../AppRun DiscordCanary/.
+#         chmod +x DiscordCanary/AppRun
+#         sed 's,BIN="$APPDIR/Discord",BIN="$APPDIR/DiscordCanary",g' -i DiscordCanary/AppRun
+#         cp ../discord.desktop DiscordCanary/.
+#         cd ..
     
-    - name: Patch AppImage
-      run: |
-        cd discord
-        wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
-        chmod +x *.AppImage
-        rm DiscordCanary/discord*canary*.desktop
-        ls DiscordCanary
-        ./appimagetool-x86_64.AppImage DiscordCanary -n -u 'gh-releases-zsync|srevinsaju|discord-appimage|canary|Discord*.AppImage.zsync' Discord-$(cat DiscordCanary/resources/build_info.json | jq -r .version)-x86_64.AppImage
-        mkdir dist
-        mv Discord*.AppImage dist/.
-        mv *.zsync dist/.
-        cd dist
-        chmod +x *.AppImage
-        cd ..
+#     - name: Patch AppImage
+#       run: |
+#         cd discord
+#         wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+#         chmod +x *.AppImage
+#         rm DiscordCanary/discord*canary*.desktop
+#         ls DiscordCanary
+#         ./appimagetool-x86_64.AppImage DiscordCanary -n -u 'gh-releases-zsync|srevinsaju|discord-appimage|canary|Discord*.AppImage.zsync' Discord-$(cat DiscordCanary/resources/build_info.json | jq -r .version)-x86_64.AppImage
+#         mkdir dist
+#         mv Discord*.AppImage dist/.
+#         mv *.zsync dist/.
+#         cd dist
+#         chmod +x *.AppImage
+#         cd ..
        
 
-    - name: Upload artifact
-      uses: actions/upload-artifact@v1.0.0
-      with:
-        name: discord-canary-continuous-x86_64.AppImage
-        path: 'discord/dist'
+#     - name: Upload artifact
+#       uses: actions/upload-artifact@v1.0.0
+#       with:
+#         name: discord-canary-continuous-x86_64.AppImage
+#         path: 'discord/dist'
 
 
-  Release-Canary:
-    needs: [Discord-Canary]
-    runs-on: ubuntu-latest
+#   Release-Canary:
+#     needs: [Discord-Canary]
+#     runs-on: ubuntu-latest
 
-    steps:
-    - uses: actions/download-artifact@v1
-      with:
-        name: discord-canary-continuous-x86_64.AppImage
+#     steps:
+#     - uses: actions/download-artifact@v1
+#       with:
+#         name: discord-canary-continuous-x86_64.AppImage
 
-    - name: Release
-      uses: marvinpinto/action-automatic-releases@latest
-      with:
-        title: Discord Canary AppImage Builds
-        automatic_release_tag: canary
-        prerelease: true
-        draft: false
-        files: |
-          discord-canary-continuous-x86_64.AppImage
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
+#     - name: Release
+#       uses: marvinpinto/action-automatic-releases@latest
+#       with:
+#         title: Discord Canary AppImage Builds
+#         automatic_release_tag: canary
+#         prerelease: true
+#         draft: false
+#         files: |
+#           discord-canary-continuous-x86_64.AppImage
+#         repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,140 +77,142 @@ jobs:
           discord-continuous-x86_64.AppImage
         repo_token: ${{ secrets.GITHUB_TOKEN }}
 
-#   Discord-PTB:
-#     runs-on: ubuntu-22.04
-#     strategy:
-#       matrix:
-#         version: ['3.8']
-#     steps:
-#     - uses: actions/checkout@v2
+  Discord-PTB:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        version: ['3.8']
+    steps:
+    - uses: actions/checkout@v2
 
-#     - name: Download Discord
-#       run: |
-#         mkdir discord
-#         cd discord
-#         wget https://discord.com/api/download/ptb\?platform\=linux\&format\=tar.gz
-#         mv * discord.tar.gz
-#         tar -xf discord.tar.gz
-#         cd ..
+    - name: Download Discord
+      run: |
+        mkdir discord
+        cd discord
+        wget https://discord.com/api/download/ptb\?platform\=linux\&format\=tar.gz
+        mv * discord.tar.gz
+        tar -xf discord.tar.gz
+        cd ..
 
-#     - name: Patch to include files
-#       run: |
-#         cd discord
-#         cp ../AppRun DiscordPTB/.
-#         chmod +x DiscordPTB/AppRun
-#         sed 's,BIN="$APPDIR/Discord",BIN="$APPDIR/DiscordPTB",g' -i DiscordPTB/AppRun
-#         cp ../discord.desktop DiscordPTB/.
-#         cd ..
+    - name: Patch to include files
+      run: |
+        cd discord
+        cp ../AppRun DiscordPTB/.
+        chmod +x DiscordPTB/AppRun
+        sed 's,BIN="$APPDIR/Discord",BIN="$APPDIR/DiscordPTB",g' -i DiscordPTB/AppRun
+        cp ../discord.desktop DiscordPTB/.
+        cd ..
     
-#     - name: Patch AppImage
-#       run: |
-#         cd discord
-#         wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
-#         chmod +x *.AppImage
-#         rm DiscordPTB/discord*ptb*.desktop
-#         ls DiscordPTB
-#         ./appimagetool-x86_64.AppImage DiscordPTB -n -u 'gh-releases-zsync|srevinsaju|discord-appimage|canary|Discord*.AppImage.zsync' Discord-$(cat DiscordPTB/resources/build_info.json | jq -r .version)-x86_64.AppImage
-#         mkdir dist
-#         mv Discord*.AppImage dist/.
-#         mv *.zsync dist/.
-#         cd dist
-#         chmod +x *.AppImage
-#         cd ..
+    - name: Patch AppImage
+      run: |
+        sudo apt install libfuse2 -y
+        cd discord
+        wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+        chmod +x *.AppImage
+        rm DiscordPTB/discord*ptb*.desktop
+        ls DiscordPTB
+        ./appimagetool-x86_64.AppImage DiscordPTB -n -u 'gh-releases-zsync|srevinsaju|discord-appimage|canary|Discord*.AppImage.zsync' Discord-$(cat DiscordPTB/resources/build_info.json | jq -r .version)-x86_64.AppImage
+        mkdir dist
+        mv Discord*.AppImage dist/.
+        mv *.zsync dist/.
+        cd dist
+        chmod +x *.AppImage
+        cd ..
        
 
-#     - name: Upload artifact
-#       uses: actions/upload-artifact@v1.0.0
-#       with:
-#         name: discord-ptb-continuous-x86_64.AppImage
-#         path: 'discord/dist'
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1.0.0
+      with:
+        name: discord-ptb-continuous-x86_64.AppImage
+        path: 'discord/dist'
 
 
-#   Release-PTB:
-#     needs: [Discord-PTB]
-#     runs-on: ubuntu-latest
+  Release-PTB:
+    needs: [Discord-PTB]
+    runs-on: ubuntu-latest
 
-#     steps:
-#     - uses: actions/download-artifact@v1
-#       with:
-#         name: discord-ptb-continuous-x86_64.AppImage
+    steps:
+    - uses: actions/download-artifact@v1
+      with:
+        name: discord-ptb-continuous-x86_64.AppImage
 
-#     - name: Release
-#       uses: marvinpinto/action-automatic-releases@latest
-#       with:
-#         title: Discord Public Test AppImage Builds
-#         automatic_release_tag: ptb
-#         prerelease: true
-#         draft: false
-#         files: |
-#           discord-ptb-continuous-x86_64.AppImage
-#         repo_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Release
+      uses: marvinpinto/action-automatic-releases@latest
+      with:
+        title: Discord Public Test AppImage Builds
+        automatic_release_tag: ptb
+        prerelease: true
+        draft: false
+        files: |
+          discord-ptb-continuous-x86_64.AppImage
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
 
-#   Discord-Canary:
-#     runs-on: ubuntu-22.04
-#     strategy:
-#       matrix:
-#         version: ['3.8']
-#     steps:
-#     - uses: actions/checkout@v2
+  Discord-Canary:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        version: ['3.8']
+    steps:
+    - uses: actions/checkout@v2
 
-#     - name: Download Discord
-#       run: |
-#         mkdir discord
-#         cd discord
-#         wget https://discord.com/api/download/canary\?platform\=linux\&format\=tar.gz
-#         mv * discord.tar.gz
-#         tar -xf discord.tar.gz
-#         cd ..
+    - name: Download Discord
+      run: |
+        mkdir discord
+        cd discord
+        wget https://discord.com/api/download/canary\?platform\=linux\&format\=tar.gz
+        mv * discord.tar.gz
+        tar -xf discord.tar.gz
+        cd ..
 
-#     - name: Patch to include files
-#       run: |
-#         cd discord
-#         cp ../AppRun DiscordCanary/.
-#         chmod +x DiscordCanary/AppRun
-#         sed 's,BIN="$APPDIR/Discord",BIN="$APPDIR/DiscordCanary",g' -i DiscordCanary/AppRun
-#         cp ../discord.desktop DiscordCanary/.
-#         cd ..
+    - name: Patch to include files
+      run: |
+        cd discord
+        cp ../AppRun DiscordCanary/.
+        chmod +x DiscordCanary/AppRun
+        sed 's,BIN="$APPDIR/Discord",BIN="$APPDIR/DiscordCanary",g' -i DiscordCanary/AppRun
+        cp ../discord.desktop DiscordCanary/.
+        cd ..
     
-#     - name: Patch AppImage
-#       run: |
-#         cd discord
-#         wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
-#         chmod +x *.AppImage
-#         rm DiscordCanary/discord*canary*.desktop
-#         ls DiscordCanary
-#         ./appimagetool-x86_64.AppImage DiscordCanary -n -u 'gh-releases-zsync|srevinsaju|discord-appimage|canary|Discord*.AppImage.zsync' Discord-$(cat DiscordCanary/resources/build_info.json | jq -r .version)-x86_64.AppImage
-#         mkdir dist
-#         mv Discord*.AppImage dist/.
-#         mv *.zsync dist/.
-#         cd dist
-#         chmod +x *.AppImage
-#         cd ..
+    - name: Patch AppImage
+      run: |
+        sudo apt install libfuse2 -y
+        cd discord
+        wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+        chmod +x *.AppImage
+        rm DiscordCanary/discord*canary*.desktop
+        ls DiscordCanary
+        ./appimagetool-x86_64.AppImage DiscordCanary -n -u 'gh-releases-zsync|srevinsaju|discord-appimage|canary|Discord*.AppImage.zsync' Discord-$(cat DiscordCanary/resources/build_info.json | jq -r .version)-x86_64.AppImage
+        mkdir dist
+        mv Discord*.AppImage dist/.
+        mv *.zsync dist/.
+        cd dist
+        chmod +x *.AppImage
+        cd ..
        
 
-#     - name: Upload artifact
-#       uses: actions/upload-artifact@v1.0.0
-#       with:
-#         name: discord-canary-continuous-x86_64.AppImage
-#         path: 'discord/dist'
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1.0.0
+      with:
+        name: discord-canary-continuous-x86_64.AppImage
+        path: 'discord/dist'
 
 
-#   Release-Canary:
-#     needs: [Discord-Canary]
-#     runs-on: ubuntu-latest
+  Release-Canary:
+    needs: [Discord-Canary]
+    runs-on: ubuntu-latest
 
-#     steps:
-#     - uses: actions/download-artifact@v1
-#       with:
-#         name: discord-canary-continuous-x86_64.AppImage
+    steps:
+    - uses: actions/download-artifact@v1
+      with:
+        name: discord-canary-continuous-x86_64.AppImage
 
-#     - name: Release
-#       uses: marvinpinto/action-automatic-releases@latest
-#       with:
-#         title: Discord Canary AppImage Builds
-#         automatic_release_tag: canary
-#         prerelease: true
-#         draft: false
-#         files: |
-#           discord-canary-continuous-x86_64.AppImage
-#         repo_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Release
+      uses: marvinpinto/action-automatic-releases@latest
+      with:
+        title: Discord Canary AppImage Builds
+        automatic_release_tag: canary
+        prerelease: true
+        draft: false
+        files: |
+          discord-canary-continuous-x86_64.AppImage
+        repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Since ubuntu 18.04 will end in may 2023. Github stop running worker on ubuntu 18.04.
[Source](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/)

ubuntu 22.04 does not come with libfuse2, so we need to install this library before using appimage.