### PR TITLE
Release pipeline work

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,6 +136,7 @@ jobs:
     - uses: actions/download-artifact@v4
       with:
         name: discord-ptb-continuous-x86_64.AppImage
+        path: ./artifacts-dir
 
     - name: Release
       uses: marvinpinto/action-automatic-releases@latest
@@ -145,7 +146,7 @@ jobs:
         prerelease: true
         draft: false
         files: |
-          discord-ptb-continuous-x86_64.AppImage
+          ./artifacts-dir/*
         repo_token: ${{ secrets.GITHUB_TOKEN }}
 
   Discord-Canary:
@@ -195,7 +196,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: discord-canary-continuous-x86_64.AppImage
-        path: 'discord/dist'
+        path: 'discord/dist/*'
 
 
   Release-Canary:
@@ -206,6 +207,7 @@ jobs:
     - uses: actions/download-artifact@v4
       with:
         name: discord-canary-continuous-x86_64.AppImage
+        path: ./artifacts-dir
 
     - name: Release
       uses: marvinpinto/action-automatic-releases@latest
@@ -215,5 +217,5 @@ jobs:
         prerelease: true
         draft: false
         files: |
-          discord-canary-continuous-x86_64.AppImage
+          ./artifacts-dir/*
         repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
         path: ./artifacts-dir
         
     - name: Debug Artifact Path
-      run: ls -R ./artifact-dir
+      run: ls -R ./artifacts-dir
       
     - name: Release
       uses: marvinpinto/action-automatic-releases@latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: discord-continuous-x86_64.AppImage
-        path: 'discord/dist'
+        path: 'discord/dist/*'
 
 
   Release:
@@ -78,7 +78,7 @@ jobs:
         prerelease: false
         draft: false
         files: |
-          ./artifacts-dir/discord-continuous-x86_64.AppImage
+          ./artifacts-dir/*
         repo_token: ${{ secrets.GITHUB_TOKEN }}
 
   Discord-PTB:
@@ -128,7 +128,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: discord-ptb-continuous-x86_64.AppImage
-        path: 'discord/dist'
+        path: 'discord/dist/*'
 
 
   Release-PTB:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,10 +66,7 @@ jobs:
       with:
         name: discord-continuous-x86_64.AppImage
         path: ./artifacts-dir
-        
-    - name: Debug Artifact Path
-      run: ls -R ./artifacts-dir
-      
+
     - name: Release
       uses: marvinpinto/action-automatic-releases@latest
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,11 @@ jobs:
     - uses: actions/download-artifact@v4
       with:
         name: discord-continuous-x86_64.AppImage
-
+        path: ./artifacts-dir
+        
+    - name: Debug Artifact Path
+      run: ls -R ./artifact-dir
+      
     - name: Release
       uses: marvinpinto/action-automatic-releases@latest
       with:
@@ -74,7 +78,7 @@ jobs:
         prerelease: false
         draft: false
         files: |
-          discord-continuous-x86_64.AppImage
+          ./artifacts-dir/discord-continuous-x86_64.AppImage
         repo_token: ${{ secrets.GITHUB_TOKEN }}
 
   Discord-PTB:


### PR DESCRIPTION
Closes #15 

- upgrading download/upload actions did not retain same directory/zipping behaviour. 
- modified to indicate explicit paths for up/down, and wildcard the release artifact. 

See https://github.com/tadgh/discord-appimage/releases and https://github.com/tadgh/discord-appimage/actions/runs/11133071474 .


TODO: I did not use the statically defined `discord-continuous-x86_64.AppImage` names for the final release binaries, so if you want that, go nuts. 

To validate that this worked, I can successfully run 
```zsh
❯ zap install --github --from=tadgh/discord-appImage discord-appimage
? Choose a release stable
Downloading Discord-0.0.70-x86_64.AppImage of size 108 MB. 
? Proceed? Yes
Downloading discord-appimage
[i]:  100% [====================] (24 MB/s)          
? Do you want to integrate this appimage? Yes
discord-appimage installed successfully ✨


```